### PR TITLE
Changed MainScreen message

### DIFF
--- a/Wake On Lan/Modules/WOLResources/Sources/WOLResources/Resources/Strings/en.lproj/WakeOnLan.strings
+++ b/Wake On Lan/Modules/WOLResources/Sources/WOLResources/Resources/Strings/en.lproj/WakeOnLan.strings
@@ -8,5 +8,5 @@
 
 "wrong mac address length" = "MAC Address length MUST be equal to %@";
 "wake on lan unexpected error" = "Unexpected error occured";
-"empty view message" = "There is no anything here.\nPress the plus button in the top right corner.";
+"empty view message" = "There is nothing here.\nPress the plus button in the top right corner.";
 "change icon" = "Tap to change icon";


### PR DESCRIPTION
It seems like there is a small error in this sentence. 
Perhaps, it is a good idea to review other strings as well.
_____
Maybe this option is slightly better:
empty view message" = "There is nothing here.\nPress the plus button in the top right corner to add a device." 
